### PR TITLE
refactor: Move reaction response logic into a Handler protocol

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/vapor/console.git",
         "state": {
           "branch": null,
-          "revision": "5b9796d39f201b3dd06800437abd9d774a455e57",
-          "version": "3.0.2"
+          "revision": "74cfbea629d4aac34a97cead2447a6870af1950b",
+          "version": "3.1.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/vapor/core.git",
         "state": {
           "branch": null,
-          "revision": "7f56a09995bf3c8df562be456bdcda405d9d0678",
-          "version": "3.4.1"
+          "revision": "10d33362a47fab03a067e78fb0791341d9c634fa",
+          "version": "3.9.3"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/vapor/crypto.git",
         "state": {
           "branch": null,
-          "revision": "4b85405430df1892ee3aa1554bdb477e96cf46ad",
-          "version": "3.2.0"
+          "revision": "df8eb7d8ae51787b3a0628aa3975e67666da936c",
+          "version": "3.3.3"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/vapor/database-kit.git",
         "state": {
           "branch": null,
-          "revision": "acdd4d3384ec0122dcfcca8d23d9054a2860ffba",
-          "version": "1.2.0"
+          "revision": "8f352c8e66dab301ab9bfef912a01ce1361ba1e4",
+          "version": "1.3.3"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/vapor/fluent.git",
         "state": {
           "branch": null,
-          "revision": "058b4579aea61dd05012f121fa9fa9042488c57b",
-          "version": "3.0.0-rc.4.0.2"
+          "revision": "783819d8838d15e1a05b459aa0fd1bde1e37ac26",
+          "version": "3.2.1"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/vapor/fluent-sqlite.git",
         "state": {
           "branch": null,
-          "revision": "83075582da7414e5b3cdf179266381dec5a106b0",
-          "version": "3.0.0-rc.4.0.1"
+          "revision": "c32f5bda84bf4ea691d19afe183d40044f579e11",
+          "version": "3.0.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/vapor/http.git",
         "state": {
           "branch": null,
-          "revision": "8123ea00e9858b369cd168d0303d33e7d3804d19",
-          "version": "3.0.7"
+          "revision": "3808ed0401379b6e9f4a053f03090ea9d658caa9",
+          "version": "3.2.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/vapor/multipart.git",
         "state": {
           "branch": null,
-          "revision": "7778dcb62f3efa845e8e2808937bb347575ba7ce",
-          "version": "3.0.1"
+          "revision": "f063180d0b84832accd33194e06ed3c41f8609ac",
+          "version": "3.1.1"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/sharplet/Regex.git",
         "state": {
           "branch": null,
-          "revision": "3e671ed911b467c0d9c05e56f03d9e5bcb535f39",
-          "version": "1.1.0"
+          "revision": "a819aed0e9555268c29a62500fe6fb781ae7f57d",
+          "version": "2.1.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/vapor/routing.git",
         "state": {
           "branch": null,
-          "revision": "3219e328491b0853b8554c5a694add344d2c6cfb",
-          "version": "3.0.1"
+          "revision": "d76f339c9716785e5079af9d7075d28ff7da3d92",
+          "version": "3.1.0"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/vapor/service.git",
         "state": {
           "branch": null,
-          "revision": "281a70b69783891900be31a9e70051b6fe19e146",
-          "version": "1.0.0"
+          "revision": "fa5b5de62bd68bcde9a69933f31319e46c7275fb",
+          "version": "1.0.2"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/vapor/sql.git",
         "state": {
           "branch": null,
-          "revision": "5127aaf2eb7e5dec134739df17fc7e565024e416",
-          "version": "2.0.0-beta.2"
+          "revision": "50eaeb8f52a1ce63f1ff3880e1114dd8757a78a6",
+          "version": "2.3.2"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/vapor/sqlite.git",
         "state": {
           "branch": null,
-          "revision": "3a731525e99bcd84bf6b2c4015fe89510a07a6a4",
-          "version": "3.0.0-rc.4.0.1"
+          "revision": "314d9cd21165bcf14215e336a23ff8214f40e411",
+          "version": "3.2.1"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "695afc5205aaa49fca092b94b479ff71c43d9d3c",
-          "version": "1.8.0"
+          "revision": "ba7970fe396e8198b84c6c1b44b38a1d4e2eb6bd",
+          "version": "1.14.1"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "0adc938bc8de3d3829b842f9767d81c7480b8403",
-          "version": "1.1.1"
+          "revision": "0f3999f3e3c359cc74480c292644c3419e44a12f",
+          "version": "1.4.0"
         }
       },
       {
@@ -159,8 +159,8 @@
         "repositoryURL": "https://github.com/vapor/template-kit.git",
         "state": {
           "branch": null,
-          "revision": "43b57b5861d5181b906ac6411d28645e980bb638",
-          "version": "1.0.1"
+          "revision": "51405c83e95e8adb09565278a5e9b959c605e56c",
+          "version": "1.4.0"
         }
       },
       {
@@ -168,8 +168,8 @@
         "repositoryURL": "https://github.com/vapor/url-encoded-form.git",
         "state": {
           "branch": null,
-          "revision": "57cf7fb9c1a1014c50bc05123684a9139ad44127",
-          "version": "1.0.3"
+          "revision": "82d8d63bdb76b6dd8febe916c639ab8608dbbaed",
+          "version": "1.0.6"
         }
       },
       {
@@ -177,8 +177,8 @@
         "repositoryURL": "https://github.com/vapor/validation.git",
         "state": {
           "branch": null,
-          "revision": "ab6c5a352d97c8687b91ed4963aef8e7cfe0795b",
-          "version": "2.0.0"
+          "revision": "4de213cf319b694e4ce19e5339592601d4dd3ff6",
+          "version": "2.1.1"
         }
       },
       {
@@ -186,8 +186,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "74a46ecacca51d326a1e8cf4b7967827765f05bf",
-          "version": "3.0.5"
+          "revision": "92a58a9a84e4330500b99fe355a94d29f67abe58",
+          "version": "3.3.1"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/vapor/websocket.git",
         "state": {
           "branch": null,
-          "revision": "141cb4d3814dc8062cb0b2f43e72801b5dfcf272",
-          "version": "1.0.1"
+          "revision": "d85e5b6dce4d04065865f77385fc3324f98178f6",
+          "version": "1.1.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent-sqlite.git", from: "3.0.0-rc.2"),
 
         // Other external libraries
-        .package(url: "https://github.com/sharplet/Regex.git", from: "1.1.0"),
+        .package(url: "https://github.com/sharplet/Regex.git", from: "2.1.0"),
     ],
     targets: [
         .target(name: "App", dependencies: ["FluentSQLite", "Vapor", "Regex"]),

--- a/Sources/App/Controllers/RipBotController.swift
+++ b/Sources/App/Controllers/RipBotController.swift
@@ -7,6 +7,7 @@
 
 import Vapor
 
+import Dispatch
 import Regex
 
 class RipBotController {
@@ -15,6 +16,13 @@ class RipBotController {
         Regex("sandwich", options: .ignoreCase) : "sandwich",
         Regex("thank(s| you)", options: .ignoreCase) : "heart",
         Regex("ripbot", options: .ignoreCase) : "robot_face",
+    ]
+
+    private let handlers: [Handler] = [
+        EmoteHandler("rip", on: "Build .*\\d+.* failed"),
+        EmoteHandler("sandwich", on: "sandwich"),
+        EmoteHandler("heart", on: "thank(s| you)"),
+        EmoteHandler("robot_face", on: "ripbot")
     ]
 
     func handle(_ request: Request, from slack: Slack) throws -> HTTPResponse {
@@ -30,39 +38,48 @@ class RipBotController {
             return HTTPResponse(status: .ok, body: challenge)
         case .event:
             let wrapper = try request.content.decode(EventWrapper.self)
-            let _ = wrapper.map { self.react(to: $0.event, with: request) }
+            let _ = wrapper.map { self.act(upon: $0.event) }
         }
 
         return HTTPResponse(status: .ok)
     }
 
-    private func react(to event: Event, with request: Request) {
-        guard let channel = event.channel else {
-            return
-        }
-
-        var reactions = Set<String>()
-        let texts = event.allTexts
-
-        reactions: for (regex, emote) in matchTable {
-            texts: for text in texts {
-                guard regex.matches(text) else {
-                    continue texts
-                }
-
-                reactions.insert(emote)
-                continue reactions
-            }
-        }
-
-        for name in reactions {
-            let reaction = Reaction(channel: channel, timestamp: event.event_ts, name: name)
-
-            do {
-                let _ = try request.client().post("https://slack.com/api/reactions.add", headers: ["Authorization": "Bearer \(KeyChain.botToken)"]) { try $0.content.encode(reaction) }
-            } catch {
-                print(error)
-            }
+    func act(upon event: Event) {
+        for handler in handlers {
+            handler.act(on: event)
         }
     }
+
+//    private func react(to event: Event, with request: Request) {
+//        guard let channel = event.channel else {
+//            return
+//        }
+//
+//        var reactions = Set<String>()
+//        let texts = event.allTexts
+//
+//        reactions: for (regex, emote) in matchTable {
+//            texts: for text in texts {
+//                guard regex.matches(text) else {
+//                    continue texts
+//                }
+//
+//                reactions.insert(emote)
+//                continue reactions
+//            }
+//        }
+//
+//        for name in reactions {
+//            let reaction = Reaction(channel: channel, timestamp: event.event_ts, name: name)
+//
+//            do {
+//                let _ = try request.client().post(
+//                  "https://slack.com/api/reactions.add",
+//                  headers: ["Authorization": "Bearer \(KeyChain.botToken)"])
+//                    { try $0.content.encode(reaction) }
+//            } catch {
+//                print(error)
+//            }
+//        }
+//    }
 }

--- a/Sources/App/Controllers/RipBotController.swift
+++ b/Sources/App/Controllers/RipBotController.swift
@@ -11,46 +11,46 @@ import Dispatch
 import Regex
 
 class RipBotController {
-	private let matchTable: [Regex: String] = [
-		Regex("Build .*\\d+.* failed") : "rip",
-		Regex("sandwich", options: .ignoreCase) : "sandwich",
-		Regex("thank(s| you)", options: .ignoreCase) : "heart",
-		Regex("ripbot", options: .ignoreCase) : "robot_face",
-	]
+    private let matchTable: [Regex: String] = [
+        Regex("Build .*\\d+.* failed") : "rip",
+        Regex("sandwich", options: .ignoreCase) : "sandwich",
+        Regex("thank(s| you)", options: .ignoreCase) : "heart",
+        Regex("ripbot", options: .ignoreCase) : "robot_face",
+    ]
 
-	private let handlers: [Handler] = [
-		EmoteHandler("rip", on: "Build .*\\d+.* failed"),
-		EmoteHandler("sandwich", on: "sandwich"),
-		EmoteHandler("heart", on: "thank(s| you)"),
-		EmoteHandler("robot_face", on: "ripbot")
-	]
+    private let handlers: [Handler] = [
+        EmoteHandler("rip", on: "Build .*\\d+.* failed"),
+        EmoteHandler("sandwich", on: "sandwich"),
+        EmoteHandler("heart", on: "thank(s| you)"),
+        EmoteHandler("robot_face", on: "ripbot")
+    ]
 
-	func handle(_ request: Request, from slack: Slack) throws -> HTTPResponse {
-		guard slack.isCanonical else {
-			throw Abort(.forbidden)
-		}
+    func handle(_ request: Request, from slack: Slack) throws -> HTTPResponse {
+        guard slack.isCanonical else {
+            throw Abort(.forbidden)
+        }
 
-		switch slack.type {
-		case .challenge:
-			guard let challenge = slack.challenge else {
-				throw Abort(.badRequest)
-			}
-			return HTTPResponse(status: .ok, body: challenge)
-		case .event:
-			let wrapper = try request.content.decode(EventWrapper.self).wait()
-			act(upon: wrapper.event)
-		}
+        switch slack.type {
+        case .challenge:
+            guard let challenge = slack.challenge else {
+                throw Abort(.badRequest)
+            }
+            return HTTPResponse(status: .ok, body: challenge)
+        case .event:
+            let wrapper = try request.content.decode(EventWrapper.self).wait()
+            act(upon: wrapper.event)
+        }
 
-		return HTTPResponse(status: .ok)
-	}
+        return HTTPResponse(status: .ok)
+    }
 
-	func act(upon event: Event) {
-		print("Handling response for event \(event.event_ts)")
+    func act(upon event: Event) {
+        print("Handling response for event \(event.event_ts)")
 
-		for handler in handlers {
-			DispatchQueue.global(qos: .background).async {
-				handler.act(on: event)
-			}
-		}
-	}
+        for handler in handlers {
+            DispatchQueue.global(qos: .background).async {
+                handler.act(on: event)
+            }
+        }
+    }
 }

--- a/Sources/App/Controllers/RipBotController.swift
+++ b/Sources/App/Controllers/RipBotController.swift
@@ -45,6 +45,8 @@ class RipBotController {
 	}
 
 	func act(upon event: Event) {
+		print("Handling response for event \(event.event_ts)")
+
 		for handler in handlers {
 			DispatchQueue.global(qos: .background).async {
 				handler.act(on: event)

--- a/Sources/App/Controllers/RipBotController.swift
+++ b/Sources/App/Controllers/RipBotController.swift
@@ -11,75 +11,44 @@ import Dispatch
 import Regex
 
 class RipBotController {
-    private let matchTable: [Regex: String] = [
-        Regex("Build .*\\d+.* failed") : "rip",
-        Regex("sandwich", options: .ignoreCase) : "sandwich",
-        Regex("thank(s| you)", options: .ignoreCase) : "heart",
-        Regex("ripbot", options: .ignoreCase) : "robot_face",
-    ]
+	private let matchTable: [Regex: String] = [
+		Regex("Build .*\\d+.* failed") : "rip",
+		Regex("sandwich", options: .ignoreCase) : "sandwich",
+		Regex("thank(s| you)", options: .ignoreCase) : "heart",
+		Regex("ripbot", options: .ignoreCase) : "robot_face",
+	]
 
-    private let handlers: [Handler] = [
-        EmoteHandler("rip", on: "Build .*\\d+.* failed"),
-        EmoteHandler("sandwich", on: "sandwich"),
-        EmoteHandler("heart", on: "thank(s| you)"),
-        EmoteHandler("robot_face", on: "ripbot")
-    ]
+	private let handlers: [Handler] = [
+		EmoteHandler("rip", on: "Build .*\\d+.* failed"),
+		EmoteHandler("sandwich", on: "sandwich"),
+		EmoteHandler("heart", on: "thank(s| you)"),
+		EmoteHandler("robot_face", on: "ripbot")
+	]
 
-    func handle(_ request: Request, from slack: Slack) throws -> HTTPResponse {
-        guard slack.isCanonical else {
-            throw Abort(.forbidden)
-        }
+	func handle(_ request: Request, from slack: Slack) throws -> HTTPResponse {
+		guard slack.isCanonical else {
+			throw Abort(.forbidden)
+		}
 
-        switch slack.type {
-        case .challenge:
-            guard let challenge = slack.challenge else {
-                throw Abort(.badRequest)
-            }
-            return HTTPResponse(status: .ok, body: challenge)
-        case .event:
-            let wrapper = try request.content.decode(EventWrapper.self)
-            let _ = wrapper.map { self.act(upon: $0.event) }
-        }
+		switch slack.type {
+		case .challenge:
+			guard let challenge = slack.challenge else {
+				throw Abort(.badRequest)
+			}
+			return HTTPResponse(status: .ok, body: challenge)
+		case .event:
+			let wrapper = try request.content.decode(EventWrapper.self).wait()
+			act(upon: wrapper.event)
+		}
 
-        return HTTPResponse(status: .ok)
-    }
+		return HTTPResponse(status: .ok)
+	}
 
-    func act(upon event: Event) {
-        for handler in handlers {
-            handler.act(on: event)
-        }
-    }
-
-//    private func react(to event: Event, with request: Request) {
-//        guard let channel = event.channel else {
-//            return
-//        }
-//
-//        var reactions = Set<String>()
-//        let texts = event.allTexts
-//
-//        reactions: for (regex, emote) in matchTable {
-//            texts: for text in texts {
-//                guard regex.matches(text) else {
-//                    continue texts
-//                }
-//
-//                reactions.insert(emote)
-//                continue reactions
-//            }
-//        }
-//
-//        for name in reactions {
-//            let reaction = Reaction(channel: channel, timestamp: event.event_ts, name: name)
-//
-//            do {
-//                let _ = try request.client().post(
-//                  "https://slack.com/api/reactions.add",
-//                  headers: ["Authorization": "Bearer \(KeyChain.botToken)"])
-//                    { try $0.content.encode(reaction) }
-//            } catch {
-//                print(error)
-//            }
-//        }
-//    }
+	func act(upon event: Event) {
+		for handler in handlers {
+			DispatchQueue.global(qos: .background).async {
+				handler.act(on: event)
+			}
+		}
+	}
 }

--- a/Sources/App/Controllers/RipBotController.swift
+++ b/Sources/App/Controllers/RipBotController.swift
@@ -45,8 +45,6 @@ class RipBotController {
     }
 
     func act(upon event: Event) {
-        print("Handling response for event \(event.event_ts)")
-
         for handler in handlers {
             DispatchQueue.global(qos: .background).async {
                 handler.act(on: event)

--- a/Sources/App/Controllers/RipBotController.swift
+++ b/Sources/App/Controllers/RipBotController.swift
@@ -37,8 +37,8 @@ class RipBotController {
             }
             return HTTPResponse(status: .ok, body: challenge)
         case .event:
-            let wrapper = try request.content.decode(EventWrapper.self).wait()
-            act(upon: wrapper.event)
+            let _ = try request.content.decode(EventWrapper.self)
+				.map { self.act(upon: $0.event) }
         }
 
         return HTTPResponse(status: .ok)

--- a/Sources/App/Handler/EmoteHandler.swift
+++ b/Sources/App/Handler/EmoteHandler.swift
@@ -41,13 +41,17 @@ class EmoteHandler : Handler {
 			"Bearer \(KeyChain.botToken)", forHTTPHeaderField: "Authorization")
 
 		do {
-			request.httpBody = try JSONEncoder().encode(reaction)
+			let data = try JSONEncoder().encode(reaction)
+			request.httpBody = data
 
 			URLSession.shared.dataTask(
 				with: request,
 				completionHandler: { _, response,_ in
-					if let response = response as? HTTPURLResponse {
-						Terminal().error("Invalid status code: \(response.statusCode)")
+					if let response = response as? HTTPURLResponse,
+						let contents = String(data: data, encoding: .utf8) {
+						let terminal = Terminal()
+						terminal.output(contents.consoleText(color: .brightYellow))
+						terminal.output("Status code: \(response.statusCode)".consoleText(color: .yellow))
 					}
 			}).resume()
 		} catch {

--- a/Sources/App/Handler/EmoteHandler.swift
+++ b/Sources/App/Handler/EmoteHandler.swift
@@ -48,21 +48,20 @@ class EmoteHandler : Handler {
 			URLSession.shared.dataTask(
 				with: request,
 				completionHandler: { data, response, error in
-					if let _ = error { return }
-
-					let terminal = Terminal()
-
-					guard let _ = response as? HTTPURLResponse else {
-						terminal.error("Incorrect response type.")
+					if let error = error {
+						Terminal().error(error.localizedDescription)
 						return
 					}
 
-					guard let data = data, let contents = String(data: data, encoding: .utf8) else {
-						terminal.error("Could not parse response")
+					guard let response = response as? HTTPURLResponse else {
+						Terminal().error("Incorrect response type.")
 						return
 					}
 
-					terminal.output(contents.consoleText(color: .brightYellow))
+					guard response.statusCode == 200 else {
+						Terminal().error("Invalid status code: \(response.statusCode)")
+						return
+					}
 			}).resume()
 		} catch {
 			Terminal().error("Error making reaction \(emote) to message \(event.event_ts): \(error.localizedDescription)")

--- a/Sources/App/Handler/EmoteHandler.swift
+++ b/Sources/App/Handler/EmoteHandler.swift
@@ -45,7 +45,11 @@ class EmoteHandler : Handler {
 
 			URLSession.shared.dataTask(
 				with: request,
-				completionHandler: { _,_,_ in }).resume()
+				completionHandler: { _, response,_ in
+					if let response = response as? HTTPURLResponse {
+						Terminal().error("Invalid status code: \(response.statusCode)")
+					}
+			}).resume()
 		} catch {
 			Terminal().error("Error making reaction \(emote) to message \(event.event_ts): \(error.localizedDescription)")
 		}

--- a/Sources/App/Handler/EmoteHandler.swift
+++ b/Sources/App/Handler/EmoteHandler.swift
@@ -39,7 +39,7 @@ class EmoteHandler : Handler {
 		request.httpMethod = "POST"
 		request.setValue(
 			"Bearer \(KeyChain.botToken)", forHTTPHeaderField: "Authorization")
-//		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
 		do {
 			let body = try JSONEncoder().encode(reaction)

--- a/Sources/App/Handler/EmoteHandler.swift
+++ b/Sources/App/Handler/EmoteHandler.swift
@@ -9,8 +9,8 @@ import Foundation
 import Regex
 
 class EmoteHandler : Handler {
-    static let address = //"https://slack.com/api/reactions.add"
-        "https://www.mocky.io/v2/5185415ba171ea3a00704eed"
+    static let address = "https://slack.com/api/reactions.add"
+//        "https://www.mocky.io/v2/5185415ba171ea3a00704eed"
 
     let pattern: Regex
     let emote: String
@@ -45,12 +45,14 @@ class EmoteHandler : Handler {
                     return
                 }
 
-                guard let data = data else {
-                    print ("Error parsing data")
+                guard let data = data,
+                    let response = response as? HTTPURLResponse else {
+                    print ("Error parsing data or response")
                     return
                 }
 
                 print(String(data: data, encoding: .utf8) ?? "What string")
+                print("Status code:", response.statusCode)
             }
         } catch {
             print(error)

--- a/Sources/App/Handler/EmoteHandler.swift
+++ b/Sources/App/Handler/EmoteHandler.swift
@@ -8,56 +8,64 @@
 import Foundation
 import Regex
 
+import Console
+
 class EmoteHandler : Handler {
-    static let address = "https://slack.com/api/reactions.add"
-//        "https://www.mocky.io/v2/5185415ba171ea3a00704eed"
+	static let address = "https://slack.com/api/reactions.add"
+	//        "https://www.mocky.io/v2/5185415ba171ea3a00704eed"
 
-    let pattern: Regex
-    let emote: String
+	let pattern: Regex
+	let emote: String
 
-    init(_ emote: String, on pattern: StaticString) {
-        self.emote = emote
-        self.pattern = Regex(pattern)
-    }
+	init(_ emote: String, on pattern: StaticString) {
+		self.emote = emote
+		self.pattern = Regex(pattern)
+	}
 
-    func act(on event: Event) {
-        guard event.allTexts.allSatisfy(pattern.matches(_:)) else {
-            return
-        }
+	func act(on event: Event) {
+		guard event.allTexts.allSatisfy(pattern.matches(_:)) else {
+			return
+		}
 
-        guard let channel = event.channel,
-            let url = URL(string: EmoteHandler.address) else {
-                return
-        }
+		guard let channel = event.channel,
+			let url = URL(string: Self.address) else {
+				return
+		}
 
-        let reaction = Reaction(
-            channel: channel, timestamp: event.event_ts, name: emote)
-        var request = URLRequest(url: url)
+		let reaction = Reaction(
+			channel: channel, timestamp: event.event_ts, name: emote)
+		var request = URLRequest(url: url)
 
-        request.setValue(
-            "Bearer \(KeyChain.botToken)", forHTTPHeaderField: "Authorization")
+		request.setValue(
+			"Bearer \(KeyChain.botToken)", forHTTPHeaderField: "Authorization")
 
-        do {
-            request.httpBody = try JSONEncoder().encode(reaction)
-            URLSession.shared.dataTask(
-                with: request,
-                completionHandler: { data, response, error in
-                    if let error = error {
-                        print("Error:", error)
-                        return
-                    }
+		do {
+			request.httpBody = try JSONEncoder().encode(reaction)
+			URLSession.shared.dataTask(
+				with: request,
+				completionHandler: { data, response, error in
+					let terminal = Terminal()
 
-                    guard let data = data,
-                        let response = response as? HTTPURLResponse else {
-                        print ("Error parsing data or response")
-                        return
-                    }
+					if let error = error {
+						terminal.output("Error: ".consoleText(color: .red) + "\(error)".consoleText())
+						return
+					}
 
-                    print(String(data: data, encoding: .utf8) ?? "What string")
-                    print("Status code:", response.statusCode)
-                    }).resume()
-        } catch {
-            print(error)
-        }
-    }
+					guard let data = data,
+						let response = response as? HTTPURLResponse else {
+							terminal.error("Error parsing data or response")
+							return
+					}
+
+					guard response.statusCode == 200 else {
+						terminal.error("Invalid response code: \(response.statusCode)")
+						return
+					}
+
+					terminal.output(String(data: data, encoding: .utf8)?.consoleText() ?? "What string".consoleText())
+			}).resume()
+		} catch {
+			print(error)
+		}
+	}
 }

--- a/Sources/App/Handler/EmoteHandler.swift
+++ b/Sources/App/Handler/EmoteHandler.swift
@@ -39,21 +39,23 @@ class EmoteHandler : Handler {
 
         do {
             request.httpBody = try JSONEncoder().encode(reaction)
-            URLSession.shared.dataTask(with: request) { data, response, error in
-                if let error = error {
-                    print("Error:", error)
-                    return
-                }
+            URLSession.shared.dataTask(
+                with: request,
+                completionHandler: { data, response, error in
+                    if let error = error {
+                        print("Error:", error)
+                        return
+                    }
 
-                guard let data = data,
-                    let response = response as? HTTPURLResponse else {
-                    print ("Error parsing data or response")
-                    return
-                }
+                    guard let data = data,
+                        let response = response as? HTTPURLResponse else {
+                        print ("Error parsing data or response")
+                        return
+                    }
 
-                print(String(data: data, encoding: .utf8) ?? "What string")
-                print("Status code:", response.statusCode)
-            }
+                    print(String(data: data, encoding: .utf8) ?? "What string")
+                    print("Status code:", response.statusCode)
+                    }).resume()
         } catch {
             print(error)
         }

--- a/Sources/App/Handler/EmoteHandler.swift
+++ b/Sources/App/Handler/EmoteHandler.swift
@@ -23,8 +23,6 @@ class EmoteHandler : Handler {
 	}
 
 	func act(on event: Event) {
-		let terminal = Terminal()
-
 		guard event.allTexts.contains(where: pattern.matches(_:)) else {
 			return
 		}
@@ -36,59 +34,20 @@ class EmoteHandler : Handler {
 
 		let reaction = Reaction(
 			channel: channel, timestamp: event.event_ts, name: emote)
-		var request = URLRequest(url: url)
 
+		var request = URLRequest(url: url)
+		request.httpMethod = "POST"
 		request.setValue(
 			"Bearer \(KeyChain.botToken)", forHTTPHeaderField: "Authorization")
 
 		do {
-			terminal.output("Sending reaction \(emote).".consoleText(color: .yellow))
-			let body = try JSONEncoder().encode(reaction)
-			request.httpBody = body
-
-			let bodyString = String(data: body, encoding: .utf8)
-				?? "Could not parse body."
-			terminal.output((request.allHTTPHeaderFields?.debugDescription
-				?? "No headers found").consoleText(color: .brightMagenta))
-			terminal.output(bodyString.consoleText(color: .brightYellow))
+			request.httpBody = try JSONEncoder().encode(reaction)
 
 			URLSession.shared.dataTask(
 				with: request,
-				completionHandler: { data, response, error in
-					let terminal = Terminal()
-					print("Request sent.")
-
-					if let error = error {
-						terminal.output("Error: ".consoleText(color: .red) + "\(error)".consoleText())
-						return
-					}
-
-					guard let data = data,
-						let response = response as? HTTPURLResponse else {
-							terminal.error("Error parsing data or response")
-							return
-					}
-
-					guard response.statusCode == 200 else {
-						terminal.error("Invalid response code: \(response.statusCode)")
-
-						let content =
-							String(data: data, encoding: .utf8)
-								?? "What string"
-						let lines = content.components(separatedBy: "\n")
-						let start = max(0, lines.endIndex - 10)
-
-						for line in lines[start..<lines.endIndex].map({ $0.consoleText(color: .green) }) {
-							terminal.output(line)
-						}
-
-						return
-					}
-
-					terminal.output(String(data: data, encoding: .utf8)?.consoleText() ?? "What string".consoleText())
-			}).resume()
+				completionHandler: { _,_,_ in }).resume()
 		} catch {
-			print(error)
+			Terminal().error("Error making reaction \(emote) to message \(event.event_ts): \(error.localizedDescription)")
 		}
 	}
 }

--- a/Sources/App/Handler/EmoteHandler.swift
+++ b/Sources/App/Handler/EmoteHandler.swift
@@ -45,6 +45,7 @@ class EmoteHandler : Handler {
 				with: request,
 				completionHandler: { data, response, error in
 					let terminal = Terminal()
+					print("Request sent.")
 
 					if let error = error {
 						terminal.output("Error: ".consoleText(color: .red) + "\(error)".consoleText())

--- a/Sources/App/Handler/EmoteHandler.swift
+++ b/Sources/App/Handler/EmoteHandler.swift
@@ -1,0 +1,59 @@
+//
+//  EmoteHandler.swift
+//  App
+//
+//  Created by Eric Cormack on 12/13/19.
+//
+
+import Foundation
+import Regex
+
+class EmoteHandler : Handler {
+    static let address = //"https://slack.com/api/reactions.add"
+        "https://www.mocky.io/v2/5185415ba171ea3a00704eed"
+
+    let pattern: Regex
+    let emote: String
+
+    init(_ emote: String, on pattern: StaticString) {
+        self.emote = emote
+        self.pattern = Regex(pattern)
+    }
+
+    func act(on event: Event) {
+        guard event.allTexts.allSatisfy(pattern.matches(_:)) else {
+            return
+        }
+
+        guard let channel = event.channel,
+            let url = URL(string: EmoteHandler.address) else {
+                return
+        }
+
+        let reaction = Reaction(
+            channel: channel, timestamp: event.event_ts, name: emote)
+        var request = URLRequest(url: url)
+
+        request.setValue(
+            "Bearer \(KeyChain.botToken)", forHTTPHeaderField: "Authorization")
+
+        do {
+            request.httpBody = try JSONEncoder().encode(reaction)
+            URLSession.shared.dataTask(with: request) { data, response, error in
+                if let error = error {
+                    print("Error:", error)
+                    return
+                }
+
+                guard let data = data else {
+                    print ("Error parsing data")
+                    return
+                }
+
+                print(String(data: data, encoding: .utf8) ?? "What string")
+            }
+        } catch {
+            print(error)
+        }
+    }
+}

--- a/Sources/App/Handler/EmoteHandler.swift
+++ b/Sources/App/Handler/EmoteHandler.swift
@@ -23,12 +23,15 @@ class EmoteHandler : Handler {
 	}
 
 	func act(on event: Event) {
-		guard event.allTexts.allSatisfy(pattern.matches(_:)) else {
+		let terminal = Terminal()
+
+		guard event.allTexts.contains(where: pattern.matches(_:)) else {
 			return
 		}
 
 		guard let channel = event.channel,
 			let url = URL(string: EmoteHandler.address) else {
+				terminal.output("Channel or URL not parsed")
 				return
 		}
 
@@ -40,6 +43,7 @@ class EmoteHandler : Handler {
 			"Bearer \(KeyChain.botToken)", forHTTPHeaderField: "Authorization")
 
 		do {
+			terminal.output("Sending reaction \(emote).".consoleText(color: .yellow))
 			request.httpBody = try JSONEncoder().encode(reaction)
 			URLSession.shared.dataTask(
 				with: request,

--- a/Sources/App/Handler/EmoteHandler.swift
+++ b/Sources/App/Handler/EmoteHandler.swift
@@ -28,7 +28,7 @@ class EmoteHandler : Handler {
 		}
 
 		guard let channel = event.channel,
-			let url = URL(string: Self.address) else {
+			let url = URL(string: EmoteHandler.address) else {
 				return
 		}
 

--- a/Sources/App/Handler/EmoteHandler.swift
+++ b/Sources/App/Handler/EmoteHandler.swift
@@ -39,20 +39,30 @@ class EmoteHandler : Handler {
 		request.httpMethod = "POST"
 		request.setValue(
 			"Bearer \(KeyChain.botToken)", forHTTPHeaderField: "Authorization")
+//		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
 		do {
-			let data = try JSONEncoder().encode(reaction)
-			request.httpBody = data
+			let body = try JSONEncoder().encode(reaction)
+			request.httpBody = body
 
 			URLSession.shared.dataTask(
 				with: request,
-				completionHandler: { _, response,_ in
-					if let response = response as? HTTPURLResponse,
-						let contents = String(data: data, encoding: .utf8) {
-						let terminal = Terminal()
-						terminal.output(contents.consoleText(color: .brightYellow))
-						terminal.output("Status code: \(response.statusCode)".consoleText(color: .yellow))
+				completionHandler: { data, response, error in
+					if let _ = error { return }
+
+					let terminal = Terminal()
+
+					guard let _ = response as? HTTPURLResponse else {
+						terminal.error("Incorrect response type.")
+						return
 					}
+
+					guard let data = data, let contents = String(data: data, encoding: .utf8) else {
+						terminal.error("Could not parse response")
+						return
+					}
+
+					terminal.output(contents.consoleText(color: .brightYellow))
 			}).resume()
 		} catch {
 			Terminal().error("Error making reaction \(emote) to message \(event.event_ts): \(error.localizedDescription)")

--- a/Sources/App/Handler/Handler.swift
+++ b/Sources/App/Handler/Handler.swift
@@ -1,0 +1,12 @@
+//
+//  Handler.swift
+//  App
+//
+//  Created by Eric Cormack on 12/13/19.
+//
+
+import Foundation
+
+protocol Handler {
+    func act(on event: Event)
+}


### PR DESCRIPTION
Here we primarily create the `Handler` protocol and transfer the reaction logic into the `EmoteHandler`. This sets us up for creating other types of handlers that can be spun up with different internal logic, but working on the same methods.

Additionally, the Regex library has been updated, preventing ungodly build times when Vapor hangs on fetching the library.